### PR TITLE
Don't rely on unarchive download capabilities

### DIFF
--- a/tasks/install-guacamole-client.yml
+++ b/tasks/install-guacamole-client.yml
@@ -28,9 +28,16 @@
     path: /usr/share/tomcat/.guacamole/extensions/guacamole-auth-jdbc-mysql-{{ guacamole_version }}.jar
   register: auth_jdbc_is_installed
 
-- name: Download and unarchive guacamole-auth-jdbc-mysql
+- name: Download guacamole-auth-jdbc-mysql
+  get_url:
+    url: 'http://apache.mirrors.tds.net/incubator/guacamole/{{ guacamole_version }}/binary/guacamole-auth-jdbc-{{ guacamole_version }}.tar.gz'
+    dest: '{{ guacamole_temp_path }}'
+    timeout: 120
+  when: auth_jdbc_is_installed.stat.exists == False
+
+- name: Unarchive guacamole-auth-jdbc-mysql
   unarchive:
-    src: 'http://apache.mirrors.tds.net/incubator/guacamole/{{ guacamole_version }}/binary/guacamole-auth-jdbc-{{ guacamole_version }}.tar.gz'
+    src: '{{ guacamole_temp_path }}/guacamole-auth-jdbc-{{ guacamole_version }}.tar.gz'
     remote_src: yes
     dest: '{{ guacamole_temp_path }}'
     creates: '{{ guacamole_temp_path }}/guacamole-auth-jdbc-{{ guacamole_version }}/mysql/guacamole-auth-jdbc-mysql-{{ guacamole_version }}.jar'
@@ -51,9 +58,16 @@
     path: /usr/share/tomcat/.guacamole/lib/mysql-connector-java-5.1.42-bin.jar
   register: mysql_connector_is_installed
 
-- name: Download and unarchive mysql-connector-java
+- name: Download mysql-connector-java
+  get_url:
+    url: 'http://download.softagency.net/MySQL/Downloads/Connector-J/mysql-connector-java-5.1.42.tar.gz'
+    dest: '{{ guacamole_temp_path }}'
+    timeout: 120
+  when: mysql_connector_is_installed.stat.exists == False
+
+- name: Unarchive mysql-connector-java
   unarchive:
-    src: http://download.softagency.net/MySQL/Downloads/Connector-J/mysql-connector-java-5.1.42.tar.gz
+    src: '{{ guacamole_temp_path }}/mysql-connector-java-5.1.42.tar.gz'
     remote_src: yes
     dest: '{{ guacamole_temp_path }}'
     creates: '{{ guacamole_temp_path }}/mysql-connector-java-5.1.42/mysql-connector-java-5.1.42-bin.jar'


### PR DESCRIPTION
So we had a problem with this part, I assume the corporate transparant proxying caused the download to stall very quickly (that's what we see when downloading ourselves, we think it's some anti-virus checking in the background).

And since unarchive does not have any timeout-related setting for downloading, and as the maintainer of unarchive, I don't think adding download-capabilities to unarchive was a smart thing to do. The fix is simple, download the archive using get_url instead, with a longer timeout. I chose 120 seconds, but less would probably do as well.